### PR TITLE
jrtplib now builds using GCC with -Wall -Wextra -Werror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Created by .ignore support plugin (hsz.mobi)
-.idea/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,11 @@ else (UNIX)
 	set(CMAKE_DEBUG_POSTFIX _d)
 endif (UNIX)
 
+# Enable extra compiler warnings and mark warnings as errors: -Wall -Wextra -Werror
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
+endif(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC)
+
 if (UNIX OR JRTPLIB_COMPILE_STATIC)
 	add_library(jrtplib-static STATIC ${SOURCES} ${HEADERS})
 	if (UNIX)

--- a/src/extratransmitters/rtpfaketransmitter.cpp
+++ b/src/extratransmitters/rtpfaketransmitter.cpp
@@ -446,7 +446,7 @@ int RTPFakeTransmitter::Poll()
 	return status;
 }
 
-int RTPFakeTransmitter::WaitForIncomingData(const RTPTime &delay,bool *dataavailable)
+int RTPFakeTransmitter::WaitForIncomingData(const RTPTime &, bool *)
 {
 	return ERR_RTP_FAKETRANS_WAITNOTIMPLEMENTED;
 }
@@ -604,7 +604,7 @@ bool RTPFakeTransmitter::SupportsMulticasting()
 
 #ifdef RTP_SUPPORT_IPV4MULTICAST
 
-int RTPFakeTransmitter::JoinMulticastGroup(const RTPAddress &addr)
+int RTPFakeTransmitter::JoinMulticastGroup(const RTPAddress &)
 {
 // hrrm wonder how will manage to get multicast info thru to the UDPSINK
 /*	if (!init)
@@ -658,7 +658,7 @@ int RTPFakeTransmitter::JoinMulticastGroup(const RTPAddress &addr)
 	return ERR_RTP_FAKETRANS_NOMULTICASTSUPPORT;
 }
 
-int RTPFakeTransmitter::LeaveMulticastGroup(const RTPAddress &addr)
+int RTPFakeTransmitter::LeaveMulticastGroup(const RTPAddress &)
 {
     /*
 	if (!init)
@@ -988,7 +988,7 @@ RTPRawPacket *RTPFakeTransmitter::GetNextPacket()
 // Here the private functions start...
 
 #ifdef RTP_SUPPORT_IPV4MULTICAST
-bool RTPFakeTransmitter::SetMulticastTTL(uint8_t ttl)
+bool RTPFakeTransmitter::SetMulticastTTL(uint8_t)
 {
 /*	int ttl2,status;
 

--- a/src/rtpabortdescriptors.cpp
+++ b/src/rtpabortdescriptors.cpp
@@ -238,7 +238,7 @@ int RTPAbortDescriptors::ClearAbortSignal()
 	{
 		int8_t isset = 0;
 
-		struct timeval tv = { 0, 0 };
+		// Not used: struct timeval tv = { 0, 0 };
 
 		int status = RTPSelect(&m_descriptors[0], &isset, 1, RTPTime(0));
 		if (status < 0)

--- a/src/rtpconfig.h.in
+++ b/src/rtpconfig.h.in
@@ -34,6 +34,13 @@
 
 #define RTPCONFIG_UNIX_H
 
+#ifndef JRTPLIB_UNUSED
+/**
+ * Provide a macro to use for marking method parameters as unused.
+ */
+#define JRTPLIB_UNUSED(x) (void)(x)
+#endif // JRTPLIB_UNUSED
+
 #define JRTPLIB_IMPORT ${JRTPLIB_IMPORT}
 #define JRTPLIB_EXPORT ${JRTPLIB_EXPORT}
 #ifdef JRTPLIB_COMPILING

--- a/src/rtpexternaltransmitter.cpp
+++ b/src/rtpexternaltransmitter.cpp
@@ -421,12 +421,12 @@ int RTPExternalTransmitter::SendRTCPData(const void *data,size_t len)
 	return 0;
 }
 
-int RTPExternalTransmitter::AddDestination(const RTPAddress &addr)
+int RTPExternalTransmitter::AddDestination(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NODESTINATIONSSUPPORTED;
 }
 
-int RTPExternalTransmitter::DeleteDestination(const RTPAddress &addr)
+int RTPExternalTransmitter::DeleteDestination(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NODESTINATIONSSUPPORTED;
 }
@@ -440,12 +440,12 @@ bool RTPExternalTransmitter::SupportsMulticasting()
 	return false;
 }
 
-int RTPExternalTransmitter::JoinMulticastGroup(const RTPAddress &addr)
+int RTPExternalTransmitter::JoinMulticastGroup(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NOMULTICASTSUPPORT;
 }
 
-int RTPExternalTransmitter::LeaveMulticastGroup(const RTPAddress &addr)
+int RTPExternalTransmitter::LeaveMulticastGroup(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NOMULTICASTSUPPORT;
 }
@@ -474,12 +474,12 @@ int RTPExternalTransmitter::SetReceiveMode(RTPTransmitter::ReceiveMode m)
 	return 0;
 }
 
-int RTPExternalTransmitter::AddToIgnoreList(const RTPAddress &addr)
+int RTPExternalTransmitter::AddToIgnoreList(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NOIGNORELIST;
 }
 
-int RTPExternalTransmitter::DeleteFromIgnoreList(const RTPAddress &addr)
+int RTPExternalTransmitter::DeleteFromIgnoreList(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NOIGNORELIST;
 }
@@ -488,12 +488,12 @@ void RTPExternalTransmitter::ClearIgnoreList()
 {
 }
 
-int RTPExternalTransmitter::AddToAcceptList(const RTPAddress &addr)
+int RTPExternalTransmitter::AddToAcceptList(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NOACCEPTLIST;
 }
 
-int RTPExternalTransmitter::DeleteFromAcceptList(const RTPAddress &addr)
+int RTPExternalTransmitter::DeleteFromAcceptList(const RTPAddress &)
 {
 	return ERR_RTP_EXTERNALTRANS_NOACCEPTLIST;
 }

--- a/src/rtpmemorymanager.h
+++ b/src/rtpmemorymanager.h
@@ -181,6 +181,7 @@ inline void *operator new(size_t numbytes, jrtplib::RTPMemoryManager *mgr, int m
 
 inline void operator delete(void *buffer, jrtplib::RTPMemoryManager *mgr, int memtype)
 {
+	JRTPLIB_UNUSED(memtype);
 	if (mgr == 0)
 		operator delete(buffer);
 	else
@@ -197,6 +198,7 @@ inline void *operator new[](size_t numbytes, jrtplib::RTPMemoryManager *mgr, int
 
 inline void operator delete[](void *buffer, jrtplib::RTPMemoryManager *mgr, int memtype)
 {
+	JRTPLIB_UNUSED(memtype);
 	if (mgr == 0)
 		operator delete[](buffer);
 	else

--- a/src/rtpsession.h
+++ b/src/rtpsession.h
@@ -462,7 +462,7 @@ protected:
 	 *  RTCP packets. Note that when the session is destroyed, this RTPTransmitter 
 	 *  instance will be destroyed as well.
  	 */
-	virtual RTPTransmitter *NewUserDefinedTransmitter()						{ return 0; }
+	virtual RTPTransmitter *NewUserDefinedTransmitter();
 	
 	/** Is called when an incoming RTP packet is about to be processed. 
 	 *  Is called when an incoming RTP packet is about to be processed. This is _not_
@@ -470,94 +470,93 @@ protected:
 	 *  over the sources using the GotoFirst/GotoNext functions. In that case, the
 	 *  RTPSession::OnValidatedRTPPacket function should be used.
 	 */
-	virtual void OnRTPPacket(RTPPacket *pack,const RTPTime &receivetime,
-	                         const RTPAddress *senderaddress) 					{ }
+	virtual void OnRTPPacket(RTPPacket *pack,const RTPTime &receivetime, const RTPAddress *senderaddress);
 
 	/** Is called when an incoming RTCP packet is about to be processed. */
 	virtual void OnRTCPCompoundPacket(RTCPCompoundPacket *pack,const RTPTime &receivetime,
-	                                  const RTPAddress *senderaddress) 				{ }
+	                                  const RTPAddress *senderaddress);
 
 	/** Is called when an SSRC collision was detected. 
 	 *  Is called when an SSRC collision was detected. The instance \c srcdat is the one present in 
 	 *  the table, the address \c senderaddress is the one that collided with one of the addresses 
 	 *  and \c isrtp indicates against which address of \c srcdat the check failed.
 	 */
-	virtual void OnSSRCCollision(RTPSourceData *srcdat,const RTPAddress *senderaddress,bool isrtp)	{ }
+	virtual void OnSSRCCollision(RTPSourceData *srcdat,const RTPAddress *senderaddress,bool isrtp);
 
 	/** Is called when another CNAME was received than the one already present for source \c srcdat. */
 	virtual void OnCNAMECollision(RTPSourceData *srcdat,const RTPAddress *senderaddress,
-	                              const uint8_t *cname,size_t cnamelength)				{ }
+	                              const uint8_t *cname,size_t cnamelength);
 
 	/** Is called when a new entry \c srcdat is added to the source table. */
-	virtual void OnNewSource(RTPSourceData *srcdat)			 				{ }
+	virtual void OnNewSource(RTPSourceData *srcdat);
 
 	/** Is called when the entry \c srcdat is about to be deleted from the source table. */
-	virtual void OnRemoveSource(RTPSourceData *srcdat)						{ }
+	virtual void OnRemoveSource(RTPSourceData *srcdat);
 	
 	/** Is called when participant \c srcdat is timed out. */
-	virtual void OnTimeout(RTPSourceData *srcdat)							{ }
+	virtual void OnTimeout(RTPSourceData *srcdat);
 
 	/** Is called when participant \c srcdat is timed after having sent a BYE packet. */
-	virtual void OnBYETimeout(RTPSourceData *srcdat)						{ }
+	virtual void OnBYETimeout(RTPSourceData *srcdat);
 
 	/** Is called when an RTCP APP packet \c apppacket has been received at time \c receivetime 
 	 *  from address \c senderaddress.
 	 */
 	virtual void OnAPPPacket(RTCPAPPPacket *apppacket,const RTPTime &receivetime,
-	                         const RTPAddress *senderaddress)					{ }
+	                         const RTPAddress *senderaddress);
 	
 	/** Is called when an unknown RTCP packet type was detected. */
 	virtual void OnUnknownPacketType(RTCPPacket *rtcppack,const RTPTime &receivetime,
-	                                 const RTPAddress *senderaddress)				{ }
+	                                 const RTPAddress *senderaddress);
 
 	/** Is called when an unknown packet format for a known packet type was detected. */
 	virtual void OnUnknownPacketFormat(RTCPPacket *rtcppack,const RTPTime &receivetime,
-	                                   const RTPAddress *senderaddress)				{ }
+	                                   const RTPAddress *senderaddress);
 
 	/** Is called when the SDES NOTE item for source \c srcdat has been timed out. */
-	virtual void OnNoteTimeout(RTPSourceData *srcdat)						{ }
+	virtual void OnNoteTimeout(RTPSourceData *srcdat);
 
 	/** Is called when an RTCP sender report has been processed for this source. */
-	virtual void OnRTCPSenderReport(RTPSourceData *srcdat)														{ }
+	virtual void OnRTCPSenderReport(RTPSourceData *srcdat);
 	
 	/** Is called when an RTCP receiver report has been processed for this source. */
-	virtual void OnRTCPReceiverReport(RTPSourceData *srcdat)													{ }
+	virtual void OnRTCPReceiverReport(RTPSourceData *srcdat);
 
 	/** Is called when a specific SDES item was received for this source. */
 	virtual void OnRTCPSDESItem(RTPSourceData *srcdat, RTCPSDESPacket::ItemType t,
-	                            const void *itemdata, size_t itemlength)										{ }
+	                            const void *itemdata, size_t itemlength);
 #ifdef RTP_SUPPORT_SDESPRIV
 	/** Is called when a specific SDES item of 'private' type was received for this source. */
 	virtual void OnRTCPSDESPrivateItem(RTPSourceData *srcdat, const void *prefixdata, size_t prefixlen,
-	                                   const void *valuedata, size_t valuelen)									{ }
+	                                   const void *valuedata, size_t valuelen);
 #endif // RTP_SUPPORT_SDESPRIV
 
 	/** Is called when a BYE packet has been processed for source \c srcdat. */
-	virtual void OnBYEPacket(RTPSourceData *srcdat)							{ }
+	virtual void OnBYEPacket(RTPSourceData *srcdat);
 
 	/** Is called when an RTCP compound packet has just been sent (useful to inspect outgoing RTCP data). */
-	virtual void OnSendRTCPCompoundPacket(RTCPCompoundPacket *pack)					{ }
+	virtual void OnSendRTCPCompoundPacket(RTCPCompoundPacket *pack);
 #ifdef RTP_SUPPORT_THREAD
 	/** Is called when error \c errcode was detected in the poll thread. */
-	virtual void OnPollThreadError(int errcode)							{ }
+	virtual void OnPollThreadError(int errcode);
 
 	/** Is called each time the poll thread loops.
 	 *  Is called each time the poll thread loops. This happens when incoming data was 
 	 *  detected or when it's time to send an RTCP compound packet.
 	 */
-	virtual void OnPollThreadStep()									{ }
+	virtual void OnPollThreadStep();
 
 	/** Is called when the poll thread is started.
 	 *  Is called when the poll thread is started. This happens just before entering the
 	 *  thread main loop.
 	 *  \param stop This can be used to stop the thread immediately without entering the loop.
 	*/
-	virtual void OnPollThreadStart(bool &stop)							{ }
+	virtual void OnPollThreadStart(bool &stop);
 
 	/** Is called when the poll thread is going to stop.
 	 *  Is called when the poll thread is going to stop. This happens just before termitating the thread.
 	 */
-	virtual void OnPollThreadStop()									{ }
+	virtual void OnPollThreadStop();
 #endif // RTP_SUPPORT_THREAD
 
 	/** If this is set to true, outgoing data will be passed through RTPSession::OnChangeRTPOrRTCPData
@@ -577,13 +576,12 @@ protected:
 	 *  yourself, a good way may be to do this in RTPSession::OnSentRTPOrRTCPData. If `senddata` is 
 	 *  set to 0, no packet will be sent out. This also provides a way to turn off sending RTCP 
 	 *  packets if desired. */
-	virtual int OnChangeRTPOrRTCPData(const void *origdata, size_t origlen, bool isrtp, void **senddata, size_t *sendlen)
-																	{ return ERR_RTP_RTPSESSION_CHANGEREQUESTEDBUTNOTIMPLEMENTED; } 
+	virtual int OnChangeRTPOrRTCPData(const void *origdata, size_t origlen, bool isrtp, void **senddata, size_t *sendlen);
 
 	/** This function is called when an RTP or RTCP packet was sent, it can be helpful
 	 *  when data was allocated in RTPSession::OnChangeRTPOrRTCPData to deallocate it
 	 *  here. */
-	virtual void OnSentRTPOrRTCPData(void *senddata, size_t sendlen, bool isrtp) { }
+	virtual void OnSentRTPOrRTCPData(void *senddata, size_t sendlen, bool isrtp);
 
 	/** By overriding this function, the raw incoming data can be inspected
 	 *  and modified (e.g. for encryption).
@@ -591,7 +589,7 @@ protected:
 	 *  and modified (e.g. for encryption). If the function returns `false`,
 	 *  the packet is discarded.
 	 */
-	virtual bool OnChangeIncomingData(RTPRawPacket *rawpack)					{ return true; }
+	virtual bool OnChangeIncomingData(RTPRawPacket *rawpack);
 
 	/** Allows you to use an RTP packet from the specified source directly.
 	 *  Allows you to use an RTP packet from the specified source directly. If 
@@ -603,7 +601,7 @@ protected:
 	 *  function will always process the RTP packet further and is therefore not
 	 *  really suited to actually do something with the data.
 	 */
-	virtual void OnValidatedRTPPacket(RTPSourceData *srcdat, RTPPacket *rtppack, bool isonprobation, bool *ispackethandled) { }
+	virtual void OnValidatedRTPPacket(RTPSourceData *srcdat, RTPPacket *rtppack, bool isonprobation, bool *ispackethandled);
 private:
 	int InternalCreate(const RTPSessionParams &sessparams);
 	int CreateCNAME(uint8_t *buffer,size_t *bufferlength,bool resolve);
@@ -651,6 +649,44 @@ private:
 	friend class RTPSessionSources;
 	friend class RTCPSessionPacketBuilder;
 };
+
+inline RTPTransmitter *RTPSession::NewUserDefinedTransmitter()                                          { return 0; }
+inline void RTPSession::OnRTPPacket(RTPPacket *, const RTPTime &, const RTPAddress *)                   { }
+inline void RTPSession::OnRTCPCompoundPacket(RTCPCompoundPacket *, const RTPTime &, const RTPAddress *) { }
+inline void RTPSession::OnSSRCCollision(RTPSourceData *, const RTPAddress *, bool )                     { }
+inline void RTPSession::OnCNAMECollision(RTPSourceData *, const RTPAddress *, const uint8_t *, size_t ) { }
+inline void RTPSession::OnNewSource(RTPSourceData *)                                                    { }
+inline void RTPSession::OnRemoveSource(RTPSourceData *)                                                 { }
+inline void RTPSession::OnTimeout(RTPSourceData *)                                                      { }
+inline void RTPSession::OnBYETimeout(RTPSourceData *)                                                   { }
+inline void RTPSession::OnAPPPacket(RTCPAPPPacket *, const RTPTime &, const RTPAddress *)               { }
+inline void RTPSession::OnUnknownPacketType(RTCPPacket *, const RTPTime &, const RTPAddress *)          { }
+inline void RTPSession::OnUnknownPacketFormat(RTCPPacket *, const RTPTime &, const RTPAddress *)        { }
+inline void RTPSession::OnNoteTimeout(RTPSourceData *)                                                  { }
+inline void RTPSession::OnRTCPSenderReport(RTPSourceData *)                                             { }
+inline void RTPSession::OnRTCPReceiverReport(RTPSourceData *)                                           { }
+inline void RTPSession::OnRTCPSDESItem(RTPSourceData *, RTCPSDESPacket::ItemType, const void *, size_t) { }
+
+#ifdef RTP_SUPPORT_SDESPRIV
+inline void RTPSession::OnRTCPSDESPrivateItem(RTPSourceData *, const void *, size_t, const void *, size_t) { }
+#endif // RTP_SUPPORT_SDESPRIV
+
+inline void RTPSession::OnBYEPacket(RTPSourceData *)                                                    { }
+inline void RTPSession::OnSendRTCPCompoundPacket(RTCPCompoundPacket *)                                  { }
+
+#ifdef RTP_SUPPORT_THREAD
+inline void RTPSession::OnPollThreadError(int)                                                          { }
+inline void RTPSession::OnPollThreadStep()                                                              { }
+inline void RTPSession::OnPollThreadStart(bool &)                                                       { }
+inline void RTPSession::OnPollThreadStop()                                                              { }
+#endif // RTP_SUPPORT_THREAD
+
+inline int RTPSession::OnChangeRTPOrRTCPData(const void *, size_t, bool, void **, size_t *) {
+	return ERR_RTP_RTPSESSION_CHANGEREQUESTEDBUTNOTIMPLEMENTED;
+}
+inline void RTPSession::OnSentRTPOrRTCPData(void *, size_t, bool)                                       { }
+inline bool RTPSession::OnChangeIncomingData(RTPRawPacket *)                                            { return true; }
+inline void RTPSession::OnValidatedRTPPacket(RTPSourceData *, RTPPacket *, bool, bool *)                { }
 
 } // end namespace
 

--- a/src/rtpsessionparams.cpp
+++ b/src/rtpsessionparams.cpp
@@ -79,6 +79,7 @@ RTPSessionParams::RTPSessionParams() : mininterval(0,0)
 int RTPSessionParams::SetUsePollThread(bool usethread)
 {
 #ifndef RTP_SUPPORT_THREAD
+	JRTPLIB_UNUSED(usethread);
 	return ERR_RTP_NOTHREADSUPPORT;
 #else
 	usepollthread = usethread;
@@ -89,6 +90,7 @@ int RTPSessionParams::SetUsePollThread(bool usethread)
 int RTPSessionParams::SetNeedThreadSafety(bool s)
 {
 #ifndef RTP_SUPPORT_THREAD
+	JRTPLIB_UNUSED(s);
 	return ERR_RTP_NOTHREADSUPPORT;
 #else
 	m_needThreadSafety = s;

--- a/src/rtpsources.h
+++ b/src/rtpsources.h
@@ -292,51 +292,51 @@ public:
 #endif // RTPDEBUG
 protected:
 	/** Is called when an RTP packet is about to be processed. */
-	virtual void OnRTPPacket(RTPPacket *pack,const RTPTime &receivetime, const RTPAddress *senderaddress) 		{ }
+	virtual void OnRTPPacket(RTPPacket *pack,const RTPTime &receivetime, const RTPAddress *senderaddress);
 
 	/** Is called when an RTCP compound packet is about to be processed. */
-	virtual void OnRTCPCompoundPacket(RTCPCompoundPacket *pack,const RTPTime &receivetime, 
-	                                  const RTPAddress *senderaddress) 											{ }
+	virtual void OnRTCPCompoundPacket(RTCPCompoundPacket *pack,const RTPTime &receivetime,
+	                                  const RTPAddress *senderaddress);
 
 	/** Is called when an SSRC collision was detected.
 	 *  Is called when an SSRC collision was detected. The instance \c srcdat is the one present in 
 	 *  the table, the address \c senderaddress is the one that collided with one of the addresses 
 	 *  and \c isrtp indicates against which address of \c srcdat the check failed.
 	 */
-	virtual void OnSSRCCollision(RTPSourceData *srcdat,const RTPAddress *senderaddress,bool isrtp)  			{ }
+	virtual void OnSSRCCollision(RTPSourceData *srcdat,const RTPAddress *senderaddress,bool isrtp);
 
 	/** Is called when another CNAME was received than the one already present for source \c srcdat. */
 	virtual void OnCNAMECollision(RTPSourceData *srcdat,const RTPAddress *senderaddress,
-	                              const uint8_t *cname,size_t cnamelength)										{ }
+	                              const uint8_t *cname,size_t cnamelength);
 
 	/** Is called when a new entry \c srcdat is added to the source table. */
-	virtual void OnNewSource(RTPSourceData *srcdat)			 													{ }
+	virtual void OnNewSource(RTPSourceData *srcdat);
 
 	/** Is called when the entry \c srcdat is about to be deleted from the source table. */
-	virtual void OnRemoveSource(RTPSourceData *srcdat)															{ }
+	virtual void OnRemoveSource(RTPSourceData *srcdat);
 
 	/** Is called when participant \c srcdat is timed out. */
-	virtual void OnTimeout(RTPSourceData *srcdat)																{ }
+	virtual void OnTimeout(RTPSourceData *srcdat);
 
 	/** Is called when participant \c srcdat is timed after having sent a BYE packet. */
-	virtual void OnBYETimeout(RTPSourceData *srcdat)															{ }
+	virtual void OnBYETimeout(RTPSourceData *srcdat);
 
 	/** Is called when a BYE packet has been processed for source \c srcdat. */
-	virtual void OnBYEPacket(RTPSourceData *srcdat)																{ }
+	virtual void OnBYEPacket(RTPSourceData *srcdat);
 
 	/** Is called when an RTCP sender report has been processed for this source. */
-	virtual void OnRTCPSenderReport(RTPSourceData *srcdat)														{ }
+	virtual void OnRTCPSenderReport(RTPSourceData *srcdat);
 	
 	/** Is called when an RTCP receiver report has been processed for this source. */
-	virtual void OnRTCPReceiverReport(RTPSourceData *srcdat)													{ }
+	virtual void OnRTCPReceiverReport(RTPSourceData *srcdat);
 
 	/** Is called when a specific SDES item was received for this source. */
 	virtual void OnRTCPSDESItem(RTPSourceData *srcdat, RTCPSDESPacket::ItemType t,
-	                            const void *itemdata, size_t itemlength)										{ }
+	                            const void *itemdata, size_t itemlength);
 #ifdef RTP_SUPPORT_SDESPRIV
 	/** Is called when a specific SDES item of 'private' type was received for this source. */
 	virtual void OnRTCPSDESPrivateItem(RTPSourceData *srcdat, const void *prefixdata, size_t prefixlen,
-	                                   const void *valuedata, size_t valuelen)									{ }
+	                                   const void *valuedata, size_t valuelen);
 #endif // RTP_SUPPORT_SDESPRIV
 	
 
@@ -344,24 +344,24 @@ protected:
 	 *  from address \c senderaddress.
 	 */
 	virtual void OnAPPPacket(RTCPAPPPacket *apppacket,const RTPTime &receivetime,
-	                         const RTPAddress *senderaddress)													{ }
+	                         const RTPAddress *senderaddress);
 
 	/** Is called when an unknown RTCP packet type was detected. */
 	virtual void OnUnknownPacketType(RTCPPacket *rtcppack,const RTPTime &receivetime,
-	                                 const RTPAddress *senderaddress)											{ }
+	                                 const RTPAddress *senderaddress);
 
 	/** Is called when an unknown packet format for a known packet type was detected. */
 	virtual void OnUnknownPacketFormat(RTCPPacket *rtcppack,const RTPTime &receivetime,
-	                                   const RTPAddress *senderaddress)											{ }
+	                                   const RTPAddress *senderaddress);
 
 	/** Is called when the SDES NOTE item for source \c srcdat has been timed out. */
-	virtual void OnNoteTimeout(RTPSourceData *srcdat)															{ }
+	virtual void OnNoteTimeout(RTPSourceData *srcdat);
 
 	/** Allows you to use an RTP packet from the specified source directly.
 	 *  Allows you to use an RTP packet from the specified source directly. If 
 	 *  `ispackethandled` is set to `true`, the packet will no longer be stored in this
 	 *  source's packet list. */
-	virtual void OnValidatedRTPPacket(RTPSourceData *srcdat, RTPPacket *rtppack, bool isonprobation, bool *ispackethandled) { }
+	virtual void OnValidatedRTPPacket(RTPSourceData *srcdat, RTPPacket *rtppack, bool isonprobation, bool *ispackethandled);
 private:
 	void ClearSourceList();
 	int ObtainSourceDataInstance(uint32_t ssrc,RTPInternalSourceData **srcdat,bool *created);
@@ -382,6 +382,28 @@ private:
 
 	friend class RTPInternalSourceData;
 };
+
+// Inlining the default implementations to avoid unused-parameter errors.
+inline void RTPSources::OnRTPPacket(RTPPacket *, const RTPTime &, const RTPAddress *)                               { }
+inline void RTPSources::OnRTCPCompoundPacket(RTCPCompoundPacket *, const RTPTime &, const RTPAddress *)             { }
+inline void RTPSources::OnSSRCCollision(RTPSourceData *, const RTPAddress *, bool)                                  { }
+inline void RTPSources::OnCNAMECollision(RTPSourceData *, const RTPAddress *, const uint8_t *, size_t)              { }
+inline void RTPSources::OnNewSource(RTPSourceData *)                                                                { }
+inline void RTPSources::OnRemoveSource(RTPSourceData *)                                                             { }
+inline void RTPSources::OnTimeout(RTPSourceData *)                                                                  { }
+inline void RTPSources::OnBYETimeout(RTPSourceData *)                                                               { }
+inline void RTPSources::OnBYEPacket(RTPSourceData *)                                                                { }
+inline void RTPSources::OnRTCPSenderReport(RTPSourceData *)                                                         { }
+inline void RTPSources::OnRTCPReceiverReport(RTPSourceData *)                                                       { }
+inline void RTPSources::OnRTCPSDESItem(RTPSourceData *, RTCPSDESPacket::ItemType, const void *, size_t)             { }
+#ifdef RTP_SUPPORT_SDESPRIV
+inline void RTPSources::OnRTCPSDESPrivateItem(RTPSourceData *, const void *, size_t, const void *, size_t)          { }
+#endif // RTP_SUPPORT_SDESPRIV
+inline void RTPSources::OnAPPPacket(RTCPAPPPacket *, const RTPTime &, const RTPAddress *)                           { }
+inline void RTPSources::OnUnknownPacketType(RTCPPacket *, const RTPTime &, const RTPAddress *)                      { }
+inline void RTPSources::OnUnknownPacketFormat(RTCPPacket *, const RTPTime &, const RTPAddress *)                    { }
+inline void RTPSources::OnNoteTimeout(RTPSourceData *)                                                              { }
+inline void RTPSources::OnValidatedRTPPacket(RTPSourceData *, RTPPacket *, bool, bool *)                            { }
 
 } // end namespace
 

--- a/src/rtptcptransmitter.cpp
+++ b/src/rtptcptransmitter.cpp
@@ -110,6 +110,7 @@ int RTPTCPTransmitter::Init(bool tsafe)
 
 int RTPTCPTransmitter::Create(size_t maximumpacketsize, const RTPTransmissionParams *transparams)
 {
+	JRTPLIB_UNUSED(maximumpacketsize);
 	const RTPTCPTransmissionParams *params,defaultparams;
 	int status;
 
@@ -269,6 +270,7 @@ bool RTPTCPTransmitter::ComesFromThisTransmitter(const RTPAddress *addr)
 	const RTPTCPAddress *pAddr = static_cast<const RTPTCPAddress *>(addr);
 	bool v = false;
 
+	JRTPLIB_UNUSED(pAddr);
 	// TODO: for now, we're assuming that we can't just send to the same transmitter
 
 	MAINMUTEX_UNLOCK
@@ -309,7 +311,7 @@ int RTPTCPTransmitter::Poll()
 	}
 	MAINMUTEX_UNLOCK
 
-	for (int i = 0 ; i < errSockets.size() ; i++)
+	for (size_t i = 0 ; i < errSockets.size() ; i++)
 		OnReceiveError(errSockets[i]);
 
 	return status;
@@ -385,7 +387,7 @@ int RTPTCPTransmitter::WaitForIncomingData(const RTPTime &delay,bool *dataavaila
 	{
 		bool avail = false;
 
-		for (int i = 0 ; i < m_tmpFlags.size() ; i++)
+		for (size_t i = 0 ; i < m_tmpFlags.size() ; i++)
 		{
 			if (m_tmpFlags[i])
 			{
@@ -551,12 +553,12 @@ bool RTPTCPTransmitter::SupportsMulticasting()
 	return false;
 }
 
-int RTPTCPTransmitter::JoinMulticastGroup(const RTPAddress &addr)
+int RTPTCPTransmitter::JoinMulticastGroup(const RTPAddress &)
 {
 	return ERR_RTP_TCPTRANS_NOMULTICASTSUPPORT;
 }
 
-int RTPTCPTransmitter::LeaveMulticastGroup(const RTPAddress &addr)
+int RTPTCPTransmitter::LeaveMulticastGroup(const RTPAddress &)
 {
 	return ERR_RTP_TCPTRANS_NOMULTICASTSUPPORT;
 }
@@ -572,12 +574,12 @@ int RTPTCPTransmitter::SetReceiveMode(RTPTransmitter::ReceiveMode m)
 	return 0;
 }
 
-int RTPTCPTransmitter::AddToIgnoreList(const RTPAddress &addr)
+int RTPTCPTransmitter::AddToIgnoreList(const RTPAddress &)
 {
 	return ERR_RTP_TCPTRANS_RECEIVEMODENOTSUPPORTED;
 }
 
-int RTPTCPTransmitter::DeleteFromIgnoreList(const RTPAddress &addr)
+int RTPTCPTransmitter::DeleteFromIgnoreList(const RTPAddress &)
 {
 	return ERR_RTP_TCPTRANS_RECEIVEMODENOTSUPPORTED;
 }
@@ -586,12 +588,12 @@ void RTPTCPTransmitter::ClearIgnoreList()
 {
 }
 
-int RTPTCPTransmitter::AddToAcceptList(const RTPAddress &addr)
+int RTPTCPTransmitter::AddToAcceptList(const RTPAddress &)
 {
 	return ERR_RTP_TCPTRANS_RECEIVEMODENOTSUPPORTED;
 }
 
-int RTPTCPTransmitter::DeleteFromAcceptList(const RTPAddress &addr)
+int RTPTCPTransmitter::DeleteFromAcceptList(const RTPAddress &)
 {
 	return ERR_RTP_TCPTRANS_RECEIVEMODENOTSUPPORTED;
 }
@@ -727,7 +729,7 @@ int RTPTCPTransmitter::PollSocket(SocketType sock, SocketData &sdata)
 						return ERR_RTP_OUTOFMEM;
 
 					bool isrtp = true;
-					if (dataLength > sizeof(RTCPCommonHeader))
+					if (dataLength > (int)sizeof(RTCPCommonHeader))
 					{
 						RTCPCommonHeader *rtcpheader = (RTCPCommonHeader *)pBuf;
 						uint8_t packettype = rtcpheader->packettype;
@@ -877,7 +879,7 @@ void RTPTCPTransmitter::Dump()
 }
 #endif // RTPDEBUG
 
-int RTPTCPTransmitter::SendRTPRTCPData(const void *data,size_t len)	
+int RTPTCPTransmitter::SendRTPRTCPData(const void *data, size_t len)
 {
 	if (!m_init)
 		return ERR_RTP_TCPTRANS_NOTINIT;
@@ -903,7 +905,7 @@ int RTPTCPTransmitter::SendRTPRTCPData(const void *data,size_t len)
 
 	while (it != end)
 	{
-		uint8_t lengthBytes[2] = { (len >> 8)&0xff, len&0xff };
+		uint8_t lengthBytes[2] = { (uint8_t)((len >> 8)&0xff), (uint8_t)(len&0xff) };
 		SocketType sock = it->first;
 
 		if (send(sock,(const char *)lengthBytes,2,0) < 0 ||
@@ -918,14 +920,14 @@ int RTPTCPTransmitter::SendRTPRTCPData(const void *data,size_t len)
 	{
 		status = ERR_RTP_TCPTRANS_ERRORINSEND;
 
-		for (int i = 0 ; i < errSockets.size() ; i++)
+		for (size_t i = 0 ; i < errSockets.size() ; i++)
 			OnSendError(errSockets[i]);
 	}
 
 	return status;
 }
 
-int RTPTCPTransmitter::ValidateSocket(SocketType s)
+int RTPTCPTransmitter::ValidateSocket(SocketType)
 {
 	// TODO: should we even do a check (for a TCP socket)? 
 	return 0;

--- a/src/rtptcptransmitter.h
+++ b/src/rtptcptransmitter.h
@@ -143,9 +143,9 @@ public:
 #endif // RTPDEBUG
 protected:
 	// TODO
-	virtual void OnSendError(SocketType sock)														{ }
+	virtual void OnSendError(SocketType sock);
 	// TODO
-	virtual void OnReceiveError(SocketType sock)													{ }
+	virtual void OnReceiveError(SocketType sock);
 private:
 	class SocketData
 	{
@@ -190,6 +190,9 @@ private:
 	bool m_threadsafe;
 #endif // RTP_SUPPORT_THREAD
 };
+
+inline void RTPTCPTransmitter::OnSendError(SocketType) { }
+inline void RTPTCPTransmitter::OnReceiveError(SocketType) { }
 
 } // end namespace
 

--- a/src/rtptimeutilities.cpp
+++ b/src/rtptimeutilities.cpp
@@ -45,6 +45,7 @@ RTPTimeInitializerObject::RTPTimeInitializerObject()
 	std::cout << "RTPTimeInitializer: Initializing RTPTime::CurrentTime()" << std::endl;
 #endif // RTPDEBUG
 	RTPTime curtime = RTPTime::CurrentTime();
+	JRTPLIB_UNUSED(curtime);
 	dummy = -1;
 }
 

--- a/src/rtptimeutilities.h
+++ b/src/rtptimeutilities.h
@@ -195,8 +195,9 @@ inline uint32_t RTPTime::GetMicroSeconds() const
 
 	if (microsec >= 1000000)
 		return 999999;
-	if (microsec < 0)
-		return 0;
+	// Unsigned, it can never be less than 0
+	// if (microsec < 0)
+	// 	return 0;
 	return microsec;
 }
 

--- a/src/rtpudpv4transmitter.cpp
+++ b/src/rtpudpv4transmitter.cpp
@@ -1161,6 +1161,7 @@ void RTPUDPv4Transmitter::LeaveAllMulticastGroups()
 			RTPUDPV4TRANS_MCASTMEMBERSHIP(rtpsock,IP_DROP_MEMBERSHIP,mcastIP,status);
 			if (rtpsock != rtcpsock) // no need to leave multicast group twice when multiplexing
 				RTPUDPV4TRANS_MCASTMEMBERSHIP(rtcpsock,IP_DROP_MEMBERSHIP,mcastIP,status);
+			JRTPLIB_UNUSED(status);
 
 			multicastgroups.GotoNextElement();
 		}
@@ -1541,7 +1542,7 @@ int RTPUDPv4Transmitter::PollSocket(bool rtp)
 					{
 						isrtp = true;
 
-						if (recvlen > sizeof(RTCPCommonHeader))
+						if ((size_t)recvlen > sizeof(RTCPCommonHeader))
 						{
 							RTCPCommonHeader *rtcpheader = (RTCPCommonHeader *)datacopy;
 							uint8_t packettype = rtcpheader->packettype;

--- a/src/rtpudpv6transmitter.cpp
+++ b/src/rtpudpv6transmitter.cpp
@@ -936,6 +936,7 @@ void RTPUDPv6Transmitter::LeaveAllMulticastGroups()
 			RTPUDPV6TRANS_MCASTMEMBERSHIP(rtpsock,IPV6_LEAVE_GROUP,mcastIP,status);
 			RTPUDPV6TRANS_MCASTMEMBERSHIP(rtcpsock,IPV6_LEAVE_GROUP,mcastIP,status);
 			multicastgroups.GotoNextElement();
+			JRTPLIB_UNUSED(status);
 		}
 		multicastgroups.Clear();
 	}


### PR DESCRIPTION
I am trying to use jrtplib 3.10.0 in a project where we enable "all" and "extra" warnings and treat warnings as errors. That has caused me a few problems as virtual methods in some classes declares unused parameters.

In this patch, virtual methods have been split into declarations and inline implementations. This allows the implementations to avoid naming the unused variables without impacting the readability of the method declarations.

I hope it can be of use.