### PR TITLE
Update CMakeLists.txt to include FORCE_RTP_SUPPORT_IFADDRS_FALSE to it can be built on gradle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ jrtplib_include_test(sys/sockio.h RTP_HAVE_SYS_SOCKIO "// Don't have <sys/sockio
 jrtplib_include_test(ifaddrs.h RTP_SUPPORT_IFADDRS "// No ifaddrs support")
 jrtplib_include_test(netinet/in.h RTP_SUPPORT_NETINET_IN "// Don't have <netinet/in.h>")
 
+if(FORCE_RTP_SUPPORT_IFADDRS_FALSE)
+	unset(RTP_SUPPORT_IFADDRS)
+endif()
+
 if (JTHREAD_FOUND)
 	set(V "ON")
 else (JTHREAD_FOUND)
@@ -226,5 +230,3 @@ if (NOT MSVC)
 	configure_file(${PROJECT_SOURCE_DIR}/pkgconfig/jrtplib.pc.in ${PROJECT_BINARY_DIR}/pkgconfig/jrtplib.pc)
 	install(FILES ${PROJECT_BINARY_DIR}/pkgconfig/jrtplib.pc DESTINATION ${LIBRARY_INSTALL_DIR}/pkgconfig)
 endif ()
-
-

--- a/README.md
+++ b/README.md
@@ -147,3 +147,39 @@ After configuring JThread this way, just build and install it. The same CMake
 procedure for JRTPLIB should then automatically detect the correct JThread
 (so the one that's installed in your cross-compilation installation directory),
 after which you can again build and install the RTP library.
+
+Automatic Android cross compilation using cmake and gradle
+----------------------------------------------------------
+
+For Android with API versions below `24`, you need to include the quirk `arguments "-DFORCE_RTP_SUPPORT_IFADDRS_FALSE=TRUE"`, otherwise it isnt necessary as for the api number above `24`, `ifaddrs` is fully supported
+
+
+So this is how you do it in gradle:
+
+```
+defaultConfig {
+        applicationId "com.example"
+        minSdkVersion 16
+        targetSdkVersion 22
+        versionCode 1
+        versionName "1.0"
+        ndk {
+            abiFilters "armeabi-v7a", "x86"
+        }
+        externalNativeBuild {
+            cmake {
+                arguments "-DFORCE_RTP_SUPPORT_IFADDRS_FALSE=TRUE"
+            }
+        }
+    }
+
+    // Encapsulates your external native build configurations.
+    externalNativeBuild {
+
+        // Encapsulates your CMake build configurations.
+        cmake {
+            // Provides a relative path to your CMake build script.
+            path "../../JRTPLIB/CMakeLists.txt"
+        }
+    }
+```


### PR DESCRIPTION
Thanks to this answer: https://stackoverflow.com/a/49980222/6655884, If the android API is below 24, it will have ifaddrs.h but it'll now have the freeifaddrs and getifaddrs functions, so that's why the test failed for me.

I added the variable `FORCE_RTP_SUPPORT_IFADDRS_FALSE` to force it to be false after the test happens.

As an example, I was able to compile using gradle by doing:

```
defaultConfig {
        applicationId "com.jscam"
        minSdkVersion 16
        targetSdkVersion 22
        versionCode 1
        versionName "1.0"
        ndk {
            abiFilters "armeabi-v7a", "x86"
        }
        externalNativeBuild {
            cmake {
                arguments "-DFORCE_RTP_SUPPORT_IFADDRS_FALSE=TRUE"
            }
        }
    }

    // Encapsulates your external native build configurations.
    externalNativeBuild {

        // Encapsulates your CMake build configurations.
        cmake {
            // Provides a relative path to your CMake build script.
            path "../../JRTPLIB/CMakeLists.txt"
        }
    }
```