### PR TITLE
Avoid `using namespace std` to allow c++14 compilation

### DIFF
--- a/src/rtpudpv4transmitter.cpp
+++ b/src/rtpudpv4transmitter.cpp
@@ -50,8 +50,6 @@
 
 #include "rtpdebug.h"
 
-using namespace std;
-
 #define RTPUDPV4TRANS_MAXPACKSIZE							65535
 #define RTPUDPV4TRANS_IFREQBUFSIZE							8192
 
@@ -168,7 +166,7 @@ int GetAutoSockets(uint32_t bindIP, bool allowOdd, bool rtcpMux,
 {
 	const int maxAttempts = 1024;
 	int attempts = 0;
-	vector<SocketType> toClose;
+	std::vector<SocketType> toClose;
 
 	while (attempts++ < maxAttempts)
 	{


### PR DESCRIPTION
The `jrtp` library won't compile with a C++ 14 standard library due to the addition of `std::bind` which conflicts with `jrtp`'s `bind`. This only happens for the `src/rtpudpv4transmitter.cpp` file which imports the `std` namespace into the global namespace for that compilation unit.
This PR removes the `using namespace std;` statement and changes any reference to `std` names to be explicit (i.e. `std::vector`).