### PR TITLE
Let feature tests' preprocessor definition settable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ option(JRTPLIB_COMPILE_TESTS "Compile various tests in the 'tests' subdirectory"
 option(JRTPLIB_COMPILE_EXAMPLES "Compile various examples in the 'examples' subdirectory" YES)
 
 # Check winsock first
-set(TESTDEFS "")
+set(TESTDEFS "" CACHE STRING "Preprocessor definitions of feature tests")
 set(EMPTYWSSTRING "// Not using winsock sockets")
 jrtplib_test_feature(winsocktest RTP_SOCKETTYPE_WINSOCK FALSE "${EMPTYWSSTRING}" "${TESTDEFS}")
 if ("${RTP_SOCKETTYPE_WINSOCK}" STREQUAL "${EMPTYWSSTRING}")


### PR DESCRIPTION
Compile feature tests with user-defined definitions.
i.e. `-D_WIN32_WINNT=0x0501`....

If not set, wsapolltest.cpp will be compiled with i.e. `-D_WIN32_WINNT=0x0601` and define `RTP_HAVE_WSAPOLL` in rtpconfig.h. 
So when I compile my sources with `-D_WIN32_WINNT=0x0501`, error occures.